### PR TITLE
Added support to add a password explicitly

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm.java
@@ -124,23 +124,19 @@ public class MockSecurityRealm extends AbstractPasswordBasedSecurityRealm {
     }
 
     /**
-     * Return the users password if set. Otherwise return an empty string.
+     * Return the users password if set. Otherwise return username.
      * @param username
      * @return
      */
     private String getUserPassword(String username) {
-        String password = "";
+        String password = username;
         for (String line : data.split("\r?\n")) {
             String s = line.trim();
             if (s.isEmpty()) {
                 continue;
             }
-            String[] names = s.split(" +");
 
-            /**
-             * Check if password is set. If not, set username as password to have compatibility with older mock impleme-
-             * ntations
-             */
+            String[] names = s.split(" +");
             String[] usernamePassword = names[0].split("/");
 
             if (!usernamePassword[0].equals(username)) {
@@ -149,9 +145,6 @@ public class MockSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 
             if (usernamePassword.length > 1) {
                 password = usernamePassword[1];
-            }
-            else {
-                password = usernamePassword[0];
             }
         }
         return password;

--- a/src/main/resources/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm/help-data.html
+++ b/src/main/resources/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm/help-data.html
@@ -2,11 +2,11 @@
     <p>
         List of users, separated by newlines.
         Each line should have a username, optionally followed by group names (separated by spaces).
-        The password is always the same as the username.
+        Password is optional. If not set it is the same as the username.
         To set a different password use the username/password format. Passwords cannot have spaces in them.
 
-        Format : username/password group(s)
         For example:
+        <br/><b>Format : username/password group1 ... groupN</b>
     </p>
     <pre>alice
 bob/marley admins

--- a/src/main/resources/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm/help-data.html
+++ b/src/main/resources/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm/help-data.html
@@ -3,10 +3,13 @@
         List of users, separated by newlines.
         Each line should have a username, optionally followed by group names (separated by spaces).
         The password is always the same as the username.
+        To set a different password use the username/password format. Passwords cannot have spaces in them.
+
+        Format : username/password group(s)
         For example:
     </p>
     <pre>alice
-bob admins
-charlie qa
+bob/marley admins
+charlie/rocks! qa
 darlene qa admins</pre>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm/help-data.html
+++ b/src/main/resources/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealm/help-data.html
@@ -4,9 +4,9 @@
         Each line should have a username, optionally followed by group names (separated by spaces).
         Password is optional. If not set it is the same as the username.
         To set a different password use the username/password format. Passwords cannot have spaces in them.
-
-        For example:
-        <br/><b>Format : username/password group1 ... groupN</b>
+        The format is 
+        <br/><br/><b>username/password group1 ... groupN</b>
+        <br/><br/>For example:
     </p>
     <pre>alice
 bob/marley admins

--- a/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmTest.java
@@ -45,11 +45,11 @@ public class MockSecurityRealmTest {
         assertEquals("[charlie, debbie]", r.loadGroupByGroupname("qa", true).getMembers().toString());
     }
 
-    @Test public void authenticateUserWithPassword() {
+    @Test public void verifyUserWithPassword() {
         assertEquals("wonder", r.loadUserByUsername("alice").getPassword());
     }
 
-    @Test public void authenticateUserWithoutPassword() {
+    @Test public void verifyUserWithoutPassword() {
         assertEquals("bob", r.loadUserByUsername("bob").getPassword());
     }
 

--- a/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.*;
 
 public class MockSecurityRealmTest {
     
-    private final SecurityRealm r = new MockSecurityRealm("alice admin\nbob dev\ncharlie qa\ndebbie admin qa", null, false,
+    private final SecurityRealm r = new MockSecurityRealm("alice/wonder admin\nbob dev\ncharlie qa\ndebbie admin qa", null, false,
             IdStrategy.CASE_INSENSITIVE, IdStrategy.CASE_INSENSITIVE);
 
     @Test(expected=UsernameNotFoundException.class) public void nonexistentGroup() {
@@ -43,6 +43,14 @@ public class MockSecurityRealmTest {
         assertEquals("[alice, debbie]", r.loadGroupByGroupname("admin", true).getMembers().toString());
         assertEquals("[bob]", r.loadGroupByGroupname("dev", true).getMembers().toString());
         assertEquals("[charlie, debbie]", r.loadGroupByGroupname("qa", true).getMembers().toString());
+    }
+
+    @Test public void authenticateUserWithPassword() {
+        assertEquals("wonder", r.loadUserByUsername("alice").getPassword());
+    }
+
+    @Test public void authenticateUserWithoutPassword() {
+        assertEquals("bob", r.loadUserByUsername("bob").getPassword());
     }
 
 }


### PR DESCRIPTION
While mock security realm is only meant for development and test environments, for some users, even in those environments weak passwords are not allowed. 

This will allow users to create temporary passwords that will pass internal security requirements.