### PR TITLE
Adding tests for CasC compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>4.2</version>
     <relativePath />
   </parent>
 
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.164.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -57,5 +57,14 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>1.36</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmCascTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmCascTest.java
@@ -1,0 +1,58 @@
+package org.jenkinsci.plugins.mocksecurityrealm;
+
+import jenkins.model.Jenkins;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import sun.security.krb5.Realm;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class MockSecurityRealmCascTest {
+
+    @Rule public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @ConfiguredWithCode("realm-config.yml")
+    @Test public void realmIsConfigured() {
+        final MockSecurityRealm securityRealm = getMockSecurityRealm();
+
+        assertEquals("The users found in the 'admin' group are not the ones expected","[alice, debbie]", securityRealm.loadGroupByGroupname("admin", true).getMembers().toString());
+        assertEquals("The users found in the 'dev' group are not the ones expected","[bob]", securityRealm.loadGroupByGroupname("dev", true).getMembers().toString());
+        assertEquals("The users found in the 'qa' group are not the ones expected","[charlie, debbie]", securityRealm.loadGroupByGroupname("qa", true).getMembers().toString());
+
+        assertEquals("Searching for 'ADMIN' users should have returned the 'admin' users as id strategy is CASE_INSENSITIVE", "[alice, debbie]", securityRealm.loadGroupByGroupname("ADMIN", true).getMembers().toString());
+        assertEquals("Searching for 'dEv' users should have returned the 'dev' users as id strategy is CASE_INSENSITIVE","[bob]", securityRealm.loadGroupByGroupname("dEv", true).getMembers().toString());
+        assertEquals("Searching for 'qA' users should have return the 'admin' users as id strategy is CASE_INSENSITIVE", "[charlie, debbie]", securityRealm.loadGroupByGroupname("qA", true).getMembers().toString());
+
+        assertThat("Searching for 'Alice' should have returned the proper user as user id strategy is CASE_INSENSITIVE", securityRealm.loadUserByUsername("alice").getUsername(), is(securityRealm.loadUserByUsername("Alice").getUsername()));
+    }
+
+    @ConfiguredWithCode("realm-config-case-sensitive.yml")
+    @Test public void realmIsConfiguredCaseSensitive() {
+        final MockSecurityRealm securityRealm = getMockSecurityRealm();
+
+        assertEquals("The users in the 'ADMIN' group are not the expected as id strategy is CASE_SENSITIVE", "[Richard]", securityRealm.loadGroupByGroupname("ADMIN", true).getMembers().toString());
+    }
+
+    @ConfiguredWithCode("realm-config-case-sensitive.yml")
+    @Test(expected= UsernameNotFoundException.class) public void userNameIsCaseSensitive() {
+        final MockSecurityRealm securityRealm = getMockSecurityRealm();
+
+        securityRealm.loadUserByUsername("richard").getUsername();
+    }
+
+    private MockSecurityRealm getMockSecurityRealm() {
+        final Jenkins jenkins = Jenkins.get();
+        return (MockSecurityRealm) jenkins.getSecurityRealm();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mocksecurityrealm/MockSecurityRealmTest.java
@@ -42,19 +42,19 @@ public class MockSecurityRealmTest {
     }
     
     @Test public void getMembers() {
-        assertEquals("[alice, debbie]", r.loadGroupByGroupname("admin", true).getMembers().toString());
-        assertEquals("[bob]", r.loadGroupByGroupname("dev", true).getMembers().toString());
-        assertEquals("[charlie, debbie]", r.loadGroupByGroupname("qa", true).getMembers().toString());
+        assertEquals("The users found in the 'admin' group are not the ones expected", "[alice, debbie]", r.loadGroupByGroupname("admin", true).getMembers().toString());
+        assertEquals("The users found in the 'dev' group are not the ones expected", "[bob]", r.loadGroupByGroupname("dev", true).getMembers().toString());
+        assertEquals("The users found in the 'qa' group are not the ones expected","[charlie, debbie]", r.loadGroupByGroupname("qa", true).getMembers().toString());
     }
 
     @Test public void getMembersWithIdStrategy() {
-        assertEquals("[alice, debbie]", r.loadGroupByGroupname("ADMIN", true).getMembers().toString());
-        assertEquals("[bob]", r.loadGroupByGroupname("dEv", true).getMembers().toString());
-        assertEquals("[charlie, debbie]", r.loadGroupByGroupname("qA", true).getMembers().toString());
+        assertEquals("Searching for 'ADMIN' users should have returned the 'admin' users as id strategy is CASE_INSENSITIVE","[alice, debbie]", r.loadGroupByGroupname("ADMIN", true).getMembers().toString());
+        assertEquals("Searching for 'dEv' users should have returned the 'dev' users as id strategy is CASE_INSENSITIVE","[bob]", r.loadGroupByGroupname("dEv", true).getMembers().toString());
+        assertEquals("Searching for 'qA' users should have return the 'admin' users as id strategy is CASE_INSENSITIVE","[charlie, debbie]", r.loadGroupByGroupname("qA", true).getMembers().toString());
     }
 
     @Test public void getUserWithIdStrategy() {
-        assertThat(r.loadUserByUsername("alice").getUsername(), is(r.loadUserByUsername("Alice").getUsername()));
+        assertThat("Searching for 'Alice' should have returned the proper user as user id strategy is CASE_INSENSITIVE", r.loadUserByUsername("alice").getUsername(), is(r.loadUserByUsername("Alice").getUsername()));
     }
 
 }

--- a/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config-case-sensitive.yml
+++ b/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config-case-sensitive.yml
@@ -2,7 +2,5 @@ jenkins:
   securityRealm:
     mockSecurityRealm:
       data: "alice admin\nbob dev\ndebbie admin qa\nRichard ADMIN"
-      delayMillis: 5
-      randomDelay: false
       userIdStrategy: CaseSensitive
       groupIdStrategy: CaseSensitive

--- a/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config-case-sensitive.yml
+++ b/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config-case-sensitive.yml
@@ -1,0 +1,8 @@
+jenkins:
+  securityRealm:
+    mockSecurityRealm:
+      data: "alice admin\nbob dev\ndebbie admin qa\nRichard ADMIN"
+      delayMillis: 5
+      randomDelay: false
+      userIdStrategy: CaseSensitive
+      groupIdStrategy: CaseSensitive

--- a/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config.yml
+++ b/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config.yml
@@ -1,0 +1,8 @@
+jenkins:
+  securityRealm:
+    mockSecurityRealm:
+      data: "alice admin\nbob dev\ncharlie qa\ndebbie admin qa"
+      delayMillis: 5
+      randomDelay: false
+      userIdStrategy: CaseInsensitive
+      groupIdStrategy: CaseInsensitive

--- a/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config.yml
+++ b/src/test/resources/org/jenkinsci/plugins/mocksecurityrealm/realm-config.yml
@@ -2,7 +2,5 @@ jenkins:
   securityRealm:
     mockSecurityRealm:
       data: "alice admin\nbob dev\ncharlie qa\ndebbie admin qa"
-      delayMillis: 5
-      randomDelay: false
       userIdStrategy: CaseInsensitive
       groupIdStrategy: CaseInsensitive


### PR DESCRIPTION
Even if this is not a production ready plugin it is quite convenient for demos and testing, so having CasC compatibility is a good thing, at this point is CasC compatible out of the box so I have just  added a simple test to check that everything works well to make sure future changes do not break that compatibility.

TBH I do not expect that to happen but better safe than sorry. Also I have made sure the PCT still works fine with this as and all test pass when run via PCT