### PR TITLE
[JENKINS-65642] Update baseline to remove implicit dep on `trilead-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version>
+    <version>4.18</version>
     <relativePath />
   </parent>
 
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.164.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -62,9 +62,20 @@
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>1.36</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>807.v6d348e44c987</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
 </project>


### PR DESCRIPTION
The plugin depends on an old core and therefore depends on the trilead plugin (detached in 2.183/2.204 LTS).

I went with the 2.222 baseline as this is the oldest one supported by CloudBees (and I'm not sure of the BOM status for 2.204), let me know if this is an issue. Also took the opportunity to use the BOM to manage dependencies.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
